### PR TITLE
[10.x] Add toRawSql, dumpRawSql() and ddRawSql() to Query Builders

### DIFF
--- a/src/Illuminate/Database/Eloquent/Builder.php
+++ b/src/Illuminate/Database/Eloquent/Builder.php
@@ -96,9 +96,11 @@ class Builder implements BuilderContract
         'avg',
         'count',
         'dd',
+        'ddRawSql',
         'doesntExist',
         'doesntExistOr',
         'dump',
+        'dumpRawSql',
         'exists',
         'existsOr',
         'explain',
@@ -116,6 +118,7 @@ class Builder implements BuilderContract
         'rawValue',
         'sum',
         'toSql',
+        'toRawSql',
     ];
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2635,16 +2635,15 @@ class Builder implements BuilderContract
     }
 
     /**
-     * Get the raw SQL representation of the query.
+     * Get the raw SQL representation of the query with embedded bindings.
      *
      * @return string
      */
     public function toRawSql()
     {
-        $sql = $this->toSql();
-        $bindings = $this->connection->prepareBindings($this->getBindings());
-
-        return $this->grammar->makeRawSql($sql, $bindings);
+        return $this->grammar->substituteBindingsIntoRawSql(
+            $this->toSql(), $this->connection->prepareBindings($this->getBindings())
+        );
     }
 
     /**

--- a/src/Illuminate/Database/Query/Builder.php
+++ b/src/Illuminate/Database/Query/Builder.php
@@ -2635,6 +2635,19 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Get the raw SQL representation of the query.
+     *
+     * @return string
+     */
+    public function toRawSql()
+    {
+        $sql = $this->toSql();
+        $bindings = $this->connection->prepareBindings($this->getBindings());
+
+        return $this->grammar->makeRawSql($sql, $bindings);
+    }
+
+    /**
      * Execute a query for a single record by ID.
      *
      * @param  int|string  $id
@@ -3898,6 +3911,18 @@ class Builder implements BuilderContract
     }
 
     /**
+     * Dump the raw current SQL with embedded bindings.
+     *
+     * @return $this
+     */
+    public function dumpRawSql()
+    {
+        dump($this->toRawSql());
+
+        return $this;
+    }
+
+    /**
      * Die and dump the current SQL and bindings.
      *
      * @return never
@@ -3905,6 +3930,16 @@ class Builder implements BuilderContract
     public function dd()
     {
         dd($this->toSql(), $this->getBindings());
+    }
+
+    /**
+     * Die and dump the current SQL with embedded bindings.
+     *
+     * @return never
+     */
+    public function ddRawSql()
+    {
+        dd($this->toRawSql());
     }
 
     /**

--- a/src/Illuminate/Database/Query/Grammars/Grammar.php
+++ b/src/Illuminate/Database/Query/Grammars/Grammar.php
@@ -1380,8 +1380,8 @@ class Grammar extends BaseGrammar
     /**
      * Make raw SQL query.
      *
-     * @param string $sql
-     * @param array $bindings
+     * @param  string  $sql
+     * @param  array  $bindings
      * @return string
      */
     public function makeRawSql($sql, $bindings)
@@ -1399,10 +1399,10 @@ class Grammar extends BaseGrammar
             if (in_array($char.$nextChar, ["\'", "''", '??'])) {
                 $query .= $char.$nextChar;
                 $i += 1;
-            } else if ($char === "'") {
+            } elseif ($char === "'") {
                 $query .= $char;
-                $isStringLiteral = !$isStringLiteral;
-            } else if ($char === '?' && !$isStringLiteral) {
+                $isStringLiteral = ! $isStringLiteral;
+            } elseif ($char === '?' && ! $isStringLiteral) {
                 $query .= array_shift($bindings) ?? '?';
             } else {
                 $query .= $char;

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -698,4 +698,25 @@ class PostgresGrammar extends Grammar
 
         return [$attribute];
     }
+
+    /**
+     * Make raw SQL query.
+     *
+     * @param string $sql
+     * @param array $bindings
+     * @return string
+     */
+    public function makeRawSql($sql, $bindings)
+    {
+        $query = parent::makeRawSql($sql, $bindings);
+        foreach ($this->operators as $operator) {
+            if (!str_contains($operator, '?')) {
+                continue;
+            }
+
+            $query = str_replace(str_replace('?', '??', $operator), $operator, $query);
+        }
+
+        return $query;
+    }
 }

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -700,15 +700,16 @@ class PostgresGrammar extends Grammar
     }
 
     /**
-     * Make raw SQL query.
+     * Substitute the given bindings into the given raw SQL query.
      *
      * @param  string  $sql
      * @param  array  $bindings
      * @return string
      */
-    public function makeRawSql($sql, $bindings)
+    public function substituteBindingsIntoRawSql($sql, $bindings)
     {
-        $query = parent::makeRawSql($sql, $bindings);
+        $query = parent::substituteBindingsIntoRawSql($sql, $bindings);
+
         foreach ($this->operators as $operator) {
             if (! str_contains($operator, '?')) {
                 continue;

--- a/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
+++ b/src/Illuminate/Database/Query/Grammars/PostgresGrammar.php
@@ -702,15 +702,15 @@ class PostgresGrammar extends Grammar
     /**
      * Make raw SQL query.
      *
-     * @param string $sql
-     * @param array $bindings
+     * @param  string  $sql
+     * @param  array  $bindings
      * @return string
      */
     public function makeRawSql($sql, $bindings)
     {
         $query = parent::makeRawSql($sql, $bindings);
         foreach ($this->operators as $operator) {
-            if (!str_contains($operator, '?')) {
+            if (! str_contains($operator, '?')) {
                 continue;
             }
 

--- a/tests/Database/DatabaseEloquentBuilderTest.php
+++ b/tests/Database/DatabaseEloquentBuilderTest.php
@@ -2216,6 +2216,17 @@ class DatabaseEloquentBuilderTest extends TestCase
         $this->assertSame('select * from "users" where "email" = ?', $clone->toSql());
     }
 
+    public function testToRawSql()
+    {
+        $query = m::mock(BaseBuilder::class);
+        $query->shouldReceive('toRawSql')
+            ->andReturn('select * from "users" where "email" = \'foo\'');
+
+        $builder = new Builder($query);
+
+        $this->assertSame('select * from "users" where "email" = \'foo\'', $builder->toRawSql());
+    }
+
     protected function mockConnectionForModel($model, $database)
     {
         $grammarClass = 'Illuminate\Database\Query\Grammars\\'.$database.'Grammar';

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Grammars\MySqlGrammar;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseMySqlQueryGrammarTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testToRawSql()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
+        $grammar = new MySqlGrammar;
+        $grammar->setConnection($connection);
+
+        $query = $grammar->makeRawSql(
+            'select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = ?',
+            ['foo'],
+        );
+
+        $this->assertSame('select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = \'foo\'', $query);
+    }
+}

--- a/tests/Database/DatabaseMySqlQueryGrammarTest.php
+++ b/tests/Database/DatabaseMySqlQueryGrammarTest.php
@@ -21,7 +21,7 @@ class DatabaseMySqlQueryGrammarTest extends TestCase
         $grammar = new MySqlGrammar;
         $grammar->setConnection($connection);
 
-        $query = $grammar->makeRawSql(
+        $query = $grammar->substituteBindingsIntoRawSql(
             'select * from "users" where \'Hello\\\'World?\' IS NOT NULL AND "email" = ?',
             ['foo'],
         );

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Grammars\PostgresGrammar;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabasePostgresQueryGrammarTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testToRawSql()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
+        $grammar = new PostgresGrammar;
+        $grammar->setConnection($connection);
+
+        $query = $grammar->makeRawSql(
+            'select * from "users" where \'{}\' ?? \'Hello\\\'\\\'World?\' AND "email" = ?',
+            ['foo'],
+        );
+
+        $this->assertSame('select * from "users" where \'{}\' ? \'Hello\\\'\\\'World?\' AND "email" = \'foo\'', $query);
+    }
+}

--- a/tests/Database/DatabasePostgresQueryGrammarTest.php
+++ b/tests/Database/DatabasePostgresQueryGrammarTest.php
@@ -21,7 +21,7 @@ class DatabasePostgresQueryGrammarTest extends TestCase
         $grammar = new PostgresGrammar;
         $grammar->setConnection($connection);
 
-        $query = $grammar->makeRawSql(
+        $query = $grammar->substituteBindingsIntoRawSql(
             'select * from "users" where \'{}\' ?? \'Hello\\\'\\\'World?\' AND "email" = ?',
             ['foo'],
         );

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5663,6 +5663,22 @@ SQL;
         $this->assertEquals([], $clone->getBindings());
     }
 
+    public function testToRawSql()
+    {
+        $connection = m::mock(ConnectionInterface::class);
+        $connection->shouldReceive('prepareBindings')
+            ->with(['foo'])
+            ->andReturn(['foo']);
+        $grammar = m::mock(Grammar::class)->makePartial();
+        $grammar->shouldReceive('makeRawSql')
+            ->with('select * from "users" where "email" = ?', ['foo'])
+            ->andReturn('select * from "users" where "email" = \'foo\'');
+        $builder = new Builder($connection, $grammar, m::mock(Processor::class));
+        $builder->select('*')->from('users')->where('email', 'foo');
+
+        $this->assertSame('select * from "users" where "email" = \'foo\'', $builder->toRawSql());
+    }
+
     protected function getConnection()
     {
         $connection = m::mock(ConnectionInterface::class);

--- a/tests/Database/DatabaseQueryBuilderTest.php
+++ b/tests/Database/DatabaseQueryBuilderTest.php
@@ -5670,7 +5670,7 @@ SQL;
             ->with(['foo'])
             ->andReturn(['foo']);
         $grammar = m::mock(Grammar::class)->makePartial();
-        $grammar->shouldReceive('makeRawSql')
+        $grammar->shouldReceive('substituteBindingsIntoRawSql')
             ->with('select * from "users" where "email" = ?', ['foo'])
             ->andReturn('select * from "users" where "email" = \'foo\'');
         $builder = new Builder($connection, $grammar, m::mock(Processor::class));

--- a/tests/Database/DatabaseSQLiteQueryGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteQueryGrammarTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Grammars\SQLiteGrammar;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseSQLiteQueryGrammarTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testToRawSql()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
+        $grammar = new SQLiteGrammar;
+        $grammar->setConnection($connection);
+
+        $query = $grammar->makeRawSql(
+            'select * from "users" where \'Hello\'\'World?\' IS NOT NULL AND "email" = ?',
+            ['foo'],
+        );
+
+        $this->assertSame('select * from "users" where \'Hello\'\'World?\' IS NOT NULL AND "email" = \'foo\'', $query);
+    }
+}

--- a/tests/Database/DatabaseSQLiteQueryGrammarTest.php
+++ b/tests/Database/DatabaseSQLiteQueryGrammarTest.php
@@ -21,7 +21,7 @@ class DatabaseSQLiteQueryGrammarTest extends TestCase
         $grammar = new SQLiteGrammar;
         $grammar->setConnection($connection);
 
-        $query = $grammar->makeRawSql(
+        $query = $grammar->substituteBindingsIntoRawSql(
             'select * from "users" where \'Hello\'\'World?\' IS NOT NULL AND "email" = ?',
             ['foo'],
         );

--- a/tests/Database/DatabaseSqlServerQueryGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerQueryGrammarTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Illuminate\Tests\Database;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Query\Grammars\SqlServerGrammar;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+
+class DatabaseSqlServerQueryGrammarTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testToRawSql()
+    {
+        $connection = m::mock(Connection::class);
+        $connection->shouldReceive('escape')->with('foo', false)->andReturn("'foo'");
+        $grammar = new SqlServerGrammar;
+        $grammar->setConnection($connection);
+
+        $query = $grammar->makeRawSql(
+            "select * from [users] where 'Hello''World?' IS NOT NULL AND [email] = ?",
+            ['foo'],
+        );
+
+        $this->assertSame("select * from [users] where 'Hello''World?' IS NOT NULL AND [email] = 'foo'", $query);
+    }
+}

--- a/tests/Database/DatabaseSqlServerQueryGrammarTest.php
+++ b/tests/Database/DatabaseSqlServerQueryGrammarTest.php
@@ -21,7 +21,7 @@ class DatabaseSqlServerQueryGrammarTest extends TestCase
         $grammar = new SqlServerGrammar;
         $grammar->setConnection($connection);
 
-        $query = $grammar->makeRawSql(
+        $query = $grammar->substituteBindingsIntoRawSql(
             "select * from [users] where 'Hello''World?' IS NOT NULL AND [email] = ?",
             ['foo'],
         );


### PR DESCRIPTION
For quite some time, many developers have requested to get SQL queries with merged bindings from the query builder (#38027, #39053, #39551, #45705, #45189).

They want to have something like this:
```php
User::where('email', 'foo@example.com')->ddRawSql();
// "SELECT * FROM users WHERE email = 'foo@example.com'"
```

Instead of:
```php
User::where('email', 'foo@example.com')->dd();
// "SELECT * FROM users WHERE email = ?"
// [
//  0 => "foo@example.com"
// ]
```

# Prior Implementations

All prior implementations had the same issues that prevented them from being merged:

1. The bindings had been inserted into the query as strings without any further processing. Each of those generated queries was vulnerable to SQL injection attacks.
2. They replaced all question marks with values that would break on raw calls, e.g. `->whereRaw("description = 'foo?'")`

# Improved Implementation

These new ways of generating SQL queries with embedded bindings are available:

```php
$sql = User::where('email', 'foo@example.com')
  ->toRawSql();// $sql = "SELECT * FROM users WHERE email = 'foo@example.com'"

User::where('email', 'foo@example.com')
  ->dumpRawSql(); // "SELECT * FROM users WHERE email = 'foo@example.com'"

User::where('email', 'foo@example.com')
  ->ddRawSql(); // "SELECT * FROM users WHERE email = 'foo@example.com'"

$sql = DB::connection()->getQueryGrammar()->makeRawSql(
  'SELECT * FROM users WHERE email = ?',
  'foo@example.com',
); // $sql = "SELECT * FROM users WHERE email = 'foo@example.com'"
```

## 1. SQL Injections

I've built an extension for the database layer that can escape any values for safe embedding into SQL queries (#46558) that is already merged into Laravel 10.x. Based on that code, any binding is escaped before being injected into the SQL query:

```php
User::where('name', "Robert'; drop table users; --")->dd();
// "SELECT * FROM users WHERE email = 'Robert\'; drop table users; --'"
```

## 2. Ambiguous Question Marks 

Simple search-and-replace operations are not enough to reliably generate a raw SQL statement. With raw expressions anyone can embed more question marks into a SQL query that are clearly no placeholders:

```php
User::whereRaw("abc = 'Hello World?'")->where('name', 'Robert')->dd();
// "SELECT * FROM users WHERE abc = 'Hello WorldRobert' name = ?"
```

But this can also be solved relatively easily. The generated SQL string with placeholders is parsed by a very simple `LL(1)` parser (just 20 lines) to watch for string escape sequences and only replace question not being escaped in string literals:

* The occurrence of `'` starts a string literal -> no question marks will be replaced
* The occurrence of `''` and `\'` marks escaped quotes -> they are copied
* The occurrence of `'` ends a string literal -> question marks will be replaced again.

That way the generated raw SQL string have no problem with question marks in string literals:
```php
User::whereRaw("abc = 'Hello World?'")->where('name', 'Robert')->dd();
// "SELECT * FROM users WHERE abc = 'Hello World?' name = 'Robert'"
```

## 3. Executability of Raw SQL Queries
A generated query by these new functions should be able to be copied and pasted into any query tool and execute without problems. This is guaranteed for any database except PostgreSQL. Because PostgreSQL has special operators involving a question that needs to be doubled because of some PDO behaviour:

```php
User::where('json', '?', 'abc')->dd(); // json object contains key "abc"
// "SELECT * FROM users WHERE json ?? 'abc'"
```

The query can not be executed as Laravel (correctly!) doubles the question mark (double ones are exempt from replacement 😉). To also make these special queries copy-able any (1) PostgreSQL operator containing a question mark that is (2) included in Laravel's operator information is decoded again:

```php
User::where('json', '?', 'abc')->dd(); // json object contains key "abc"
// "SELECT * FROM users WHERE json ? 'abc'"
```

# Final

This implementation solves any known problems of generating raw SQL string known until today (including mine added for PostgreSQL). 

I am open to a different naming for these new methods.